### PR TITLE
templates/kselftest: thin defconfigs

### DIFF
--- a/templates/kselftest/kselftest.ini
+++ b/templates/kselftest/kselftest.ini
@@ -3,4 +3,4 @@ suite: kselftest
 set: kselftests
 description: Linux Kernel Selftests
 type: functional
-defconfigs: arm-multi_v7_defconfig,arm64-defconfig,x86-x86_64_defconfig,arm64-defconfig+kselftest,x86-defconfig+kselftest
+defconfigs: arm-multi_v7_defconfig+kselftest,arm64-defconfig+kselftest,x86-defconfig+kselftest


### PR DESCRIPTION
Only generate kselftest jobs for kernels that have been built with all
the kselftest defconfig options.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>