### PR TITLE
Add platform.mach to the LAVA v2 jobs definition

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -138,6 +138,7 @@ def main(args):
                             # print "working on device %s" % dtb
                             lpae = device['lpae']
                             device_type = device['device_type']
+                            mach = device['mach']
                             fastboot = str(device['fastboot']).lower()
                             blacklist = False
                             nfs_blacklist = False
@@ -215,6 +216,7 @@ def main(args):
                                                'dtb_url': dtb_url,
                                                'dtb_full': dtb_full,
                                                'platform': platform,
+                                               'mach': mach,
                                                'kernel_url': kernel_url,
                                                'image_type': 'kernel-ci',
                                                'image_url': base_url,

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -12,6 +12,7 @@ metadata:
   platform.dtb_short: {{ dtb_short }}
   platform.fastboot: {{ fastboot }}
   platform.name: {{ platform }}
+  platform.mach: {{ mach }}
   test.plan: {{ plan }}
   git.commit: {{ git_commit }}
   git.describe: {{ git_describe }}


### PR DESCRIPTION
Add the SoC type as platform.mach taken from the device_map to the
LAVA v2 jobs definition.  This can then be used in the KernelCI
backend as the SoC name.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>