### PR TITLE
templatest/boot: standardize indent/formatting

### DIFF
--- a/templates/base/kernel-ci-base-tftp-deploy.jinja2
+++ b/templates/base/kernel-ci-base-tftp-deploy.jinja2
@@ -7,31 +7,31 @@
 {% endblock %}
 {% block deploy %}
 actions:
-  - deploy:
-     timeout:
-       minutes: 2
-     to: tftp
-     kernel:
-         url: {{ kernel_url }}
-         type: {{ kernel_image.lower() }}
+- deploy:
+   timeout:
+     minutes: 2
+   to: tftp
+   kernel:
+       url: {{ kernel_url }}
+       type: {{ kernel_image.lower() }}
 {%- if nfsrootfs_url %}
-     nfsrootfs:
-         url: {{ nfsrootfs_url }}
-         compression: xz
+   nfsrootfs:
+       url: {{ nfsrootfs_url }}
+       compression: xz
 {%- endif %}
 {%- if initrd_url %}
-     ramdisk:
-         url: {{ initrd_url }}
-         compression: gz
+   ramdisk:
+       url: {{ initrd_url }}
+       compression: gz
 {%- endif %}
 {%- if modules_url %}
-     modules:
-         url: {{ modules_url }}
-         compression: xz
+   modules:
+       url: {{ modules_url }}
+       compression: xz
 {%- endif %}
 {%- if dtb_url %}
-     dtb:
-         url: {{ dtb_url }}
+   dtb:
+       url: {{ dtb_url }}
 {%- endif %}
-     os: oe
+   os: oe
 {% endblock %}

--- a/templates/boot/generic-grub-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-grub-tftp-ramdisk-template.jinja2
@@ -10,11 +10,11 @@
 {{ super () }}
 {%- endblock %}
 
-  - boot:
-     method: grub
-     commands: ramdisk
-     prompts:
-       - 'linaro-test'
-       - 'root@debian:~#'
-       - '/ #'
+- boot:
+   method: grub
+   commands: ramdisk
+   prompts:
+     - 'linaro-test'
+     - 'root@debian:~#'
+     - '/ #'
 {% endblock %}

--- a/templates/boot/generic-ipxe-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-ipxe-tftp-ramdisk-template.jinja2
@@ -10,11 +10,11 @@
 {{ super () }}
 {%- endblock %}
 
-  - boot:
-     method: ipxe
-     commands: ramdisk
-     prompts:
-       - 'linaro-test'
-       - 'root@debian:~#'
-       - '/ #'
+- boot:
+   method: ipxe
+   commands: ramdisk
+   prompts:
+     - 'linaro-test'
+     - 'root@debian:~#'
+     - '/ #'
 {% endblock %}

--- a/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
@@ -10,11 +10,11 @@
 {{ super () }}
 {%- endblock %}
 
-  - boot:
-     method: u-boot
-     commands: ramdisk
-     prompts:
-       - 'linaro-test'
-       - 'root@debian:~#'
-       - '/ #'
+- boot:
+   method: u-boot
+   commands: ramdisk
+   prompts:
+     - 'linaro-test'
+     - 'root@debian:~#'
+     - '/ #'
 {% endblock %}


### PR DESCRIPTION
QEMU templates don't have indentation for deploy or boot action, so
remove extra indentation from deploy and boot actions for grub/pxe/uboot
also.

This allows any additional actions which might be appended (e.g test
actions) to have the same indent level for QEMU and grub/ipxe/uboot
jobs.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>