### PR TITLE
FIXUP fix device_type name for hip07-d05

### DIFF
--- a/lib/device_map.py
+++ b/lib/device_map.py
@@ -531,7 +531,7 @@ d03 = {'device_type': 'd03',
        'fastboot': False,
        'mach': 'hisi'}
 
-d05 = {'device_type': 'd05',
+d05 = {'device_type': 'hip07-d05',
        'templates': ['generic-grub-tftp-ramdisk-template.jinja2',
                      'generic-grub-tftp-nfs-template.jinja2'],
        'kernel_defconfig_blacklist': [],


### PR DESCRIPTION
Previous patch had the wrong device type, it should match the device tree name to be consistent.