### PR TITLE
T7574 lava-v2-jobs-from-api.py: drop _rootfs:nfs suffix

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -225,7 +225,6 @@ def main(args):
                                         if 'nfs' in plan:
                                             nfsrootfs_url = NFSROOTFS_URL.format(initrd_arch)
                                             initrd_url = None
-                                            platform = platform + "_rootfs:nfs"
                                         if build['modules']:
                                             modules_url = urlparse.urljoin(base_url, build['modules'])
                                         else:


### PR DESCRIPTION
Drop the "_rootfs:nfs" suffix from the device types when running
boot-nfs test plan.  This was a hack to tell NFS boots from ramdisk
ones and it causes issues since they're not real device type names.

Note: Now that only "boot" test plan results are being pushed to the
test callback, the boot-nfs results are not treated as regular boots
but tests.  So the ramdisk and NFS boot results won't be mixed up any
more, the test plan name can be used to differentiate them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>