### PR TITLE
Add checks for known good and bad revisions

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -304,8 +304,8 @@ Bad:       ${params.BAD_COMMIT}"""
         return
     }
 
-    timeout(time: 30, unit: 'MINUTES') {
-        stage("Init") {
+    stage("Init") {
+        timeout(time: 30, unit: 'MINUTES') {
             parallel(
                 p1: { cloneKCIBuild(kci_build) },
                 p2: { cloneLinux(kdir) },
@@ -387,8 +387,8 @@ Bad:       ${params.BAD_COMMIT}"""
         return
     }
 
-    timeout(time: 5, unit: 'MINUTES') {
-        stage("Start") {
+    stage("Start") {
+        timeout(time: 5, unit: 'MINUTES') {
             def start_result = bisectStart(kdir)
 
             if (start_result) {
@@ -410,8 +410,8 @@ Bad:       ${params.BAD_COMMIT}"""
         echo "Iteration #${iteration}: ${tag}"
 
         lock("${env.NODE_NAME}-build-lock") {
-            timeout(time: 60, unit: 'MINUTES') {
-                stage("Build ${iteration}") {
+            stage("Build ${iteration}") {
+                timeout(time: 60, unit: 'MINUTES') {
                     try {
                         buildKernel(kdir, kci_build)
                         status = 0
@@ -426,8 +426,8 @@ Bad:       ${params.BAD_COMMIT}"""
             def describe = gitDescribe(kdir)
 
             node("kernel-boot-v2") {
-                timeout(time: 120, unit: 'MINUTES') {
-                    stage("Test ${iteration}") {
+                stage("Test ${iteration}") {
+                    timeout(time: 120, unit: 'MINUTES') {
                         def lava_ci = env.WORKSPACE + '/lava-ci'
                         status = runTest(lava_ci, describe)
                     }
@@ -437,8 +437,8 @@ Bad:       ${params.BAD_COMMIT}"""
 
         removeTag(kdir, tag)
 
-        timeout(time: 5, unit: 'MINUTES') {
-            stage("Next") {
+        stage("Next") {
+            timeout(time: 5, unit: 'MINUTES') {
                 bisectNext(kdir, status)
             }
         }

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -19,6 +19,17 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+/* Working around some seemingly broken Python set-up... */
+def eggCache() {
+    def egg_cache = env.WORKSPACE + "/python-egg-cache"
+    sh(script: "mkdir -p ${egg_cache}")
+    return egg_cache
+}
+
+/* ----------------------------------------------------------------------------
+ * git utilities
+ */
+
 def getSHA(kdir) {
     def sha
 
@@ -64,6 +75,10 @@ git checkout --detach ${git_rev}
 """)
     }
 }
+
+/* ----------------------------------------------------------------------------
+ * cloning projects
+ */
 
 def cloneKCIBuild(kci_build) {
     sh(script: "rm -rf ${kci_build}")
@@ -118,12 +133,9 @@ def cloneLAVA_CI(lava_ci) {
     }
 }
 
-/* Working around some seemingly broken Python set-up... */
-def eggCache() {
-    def egg_cache = env.WORKSPACE + "/python-egg-cache"
-    sh(script: "mkdir -p ${egg_cache}")
-    return egg_cache
-}
+/* ----------------------------------------------------------------------------
+ * kernel build
+ */
 
 def buildKernel(kdir, kci_build) {
     dir(kdir) {
@@ -146,6 +158,10 @@ def buildRevision(kdir, kci_build, git_rev, name) {
     buildKernel(kdir, kci_build)
     return tag
 }
+
+/* ----------------------------------------------------------------------------
+ * kernel test with LAVA v2
+ */
 
 def submitJob(lava_ci, describe) {
     dir(lava_ci) {
@@ -222,6 +238,10 @@ def runTest(lava_ci, describe) {
     return getResult(lava_ci)
 }
 
+/* ----------------------------------------------------------------------------
+ * bisection
+ */
+
 def bisectStart(kdir) {
     def status
 
@@ -258,6 +278,10 @@ def bisectNext(kdir, status) {
         }
     }
 }
+
+/* ----------------------------------------------------------------------------
+ * pipeline
+ */
 
 node("bisection") {
     def kci_build = env.WORKSPACE + '/kernelci-build'

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -243,7 +243,7 @@ def runTest(lava_ci, describe) {
  */
 
 def bisectStart(kdir) {
-    def status
+    def status = null
 
     dir(kdir) {
         status = sh(returnStatus: true, script: """
@@ -253,7 +253,7 @@ git bisect bad ${params.BAD_COMMIT}
 """)
     }
 
-    return status
+    return (status == 0) ? true : false
 }
 
 def bisectNext(kdir, status) {
@@ -368,14 +368,14 @@ Bad:       ${params.BAD_COMMIT}"""
 
     stage("Start") {
         timeout(time: 5, unit: 'MINUTES') {
-            def start_result = bisectStart(kdir)
-
-            if (start_result) {
-                echo "Failed to start bisection, commits range may be invalid."
-                currentBuild.result = 'ABORTED'
-                return
-            }
+            check = bisectStart(kdir)
         }
+    }
+
+    if (!check) {
+        echo "Failed to start bisection, commits range may be invalid."
+        currentBuild.result = 'ABORTED'
+        return
     }
 
     def previous = params.GOOD_COMMIT

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -56,6 +56,15 @@ def removeTag(kdir, tag) {
     }
 }
 
+def checkoutRevision(git_dir, git_rev) {
+    dir(git_dir) {
+        sh(script: """
+git clean -fd && \
+git checkout --detach ${git_rev}
+""")
+    }
+}
+
 def cloneKCIBuild(kci_build) {
     sh(script: "rm -rf ${kci_build}")
     dir("${kci_build}") {
@@ -240,6 +249,7 @@ def bisectNext(kdir, status) {
 node("bisection") {
     def kci_build = env.WORKSPACE + '/kernelci-build'
     def kdir = env.WORKSPACE + '/linux'
+    def check = null
 
     echo """\
 Lab:       ${params.LAB}
@@ -257,23 +267,65 @@ Bad:       ${params.BAD_COMMIT}"""
         return
     }
 
-    def start_result = 0
-
     timeout(time: 30, unit: 'MINUTES') {
         stage("Init") {
             parallel(
                 p1: { cloneKCIBuild(kci_build) },
                 p2: { cloneLinux(kdir) },
             )
-
-            start_result = bisectStart(kdir)
         }
     }
 
-    if (start_result) {
-        echo "Failed to start bisection, commits range may be invalid."
+    stage("Check pass") {
+        def tag = null
+
+        lock("${env.NODE_NAME}-build-lock") {
+            timeout(time: 60, unit: 'MINUTES') {
+                checkoutRevision(kdir, params.GOOD_COMMIT)
+                tag = createTag(kdir, 'pass')
+                try {
+                    buildKernel(kdir, kci_build)
+                    check = true
+                } catch (error) {
+                    check = false
+                }
+            }
+        }
+
+        if (!check)
+            return
+
+        def describe = gitDescribe(kdir)
+
+        node("kernel-boot-v2") {
+            timeout(time: 120, unit: 'MINUTES') {
+                def lava_ci = env.WORKSPACE + '/lava-ci'
+                cloneLAVA_CI(lava_ci)
+                submitJob(lava_ci, describe)
+                def status = getResult(lava_ci)
+                check = (status == 0 ? true : false)
+            }
+        }
+
+        removeTag(kdir, tag)
+    }
+
+    if (!check) {
+        echo "Good revision check failed"
         currentBuild.result = 'ABORTED'
         return
+    }
+
+    timeout(time: 5, unit: 'MINUTES') {
+        stage("Start") {
+            def start_result = bisectStart(kdir)
+
+            if (start_result) {
+                echo "Failed to start bisection, commits range may be invalid."
+                currentBuild.result = 'ABORTED'
+                return
+            }
+        }
     }
 
     def previous = params.GOOD_COMMIT

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -316,6 +316,46 @@ Bad:       ${params.BAD_COMMIT}"""
         return
     }
 
+    stage("Check fail") {
+        def tag = null
+
+        lock("${env.NODE_NAME}-build-lock") {
+            timeout(time: 60, unit: 'MINUTES') {
+                checkoutRevision(kdir, params.BAD_COMMIT)
+                tag = createTag(kdir, 'fail')
+                try {
+                    buildKernel(kdir, kci_build)
+                    check = true
+                } catch (error) {
+                    check = false
+                }
+            }
+        }
+
+        if (!check)
+            return
+
+        def describe = gitDescribe(kdir)
+
+        node("kernel-boot-v2") {
+            timeout(time: 120, unit: 'MINUTES') {
+                def lava_ci = env.WORKSPACE + '/lava-ci'
+                cloneLAVA_CI(lava_ci)
+                submitJob(lava_ci, describe)
+                def status = getResult(lava_ci)
+                check = (status == 2 ? true : false)
+            }
+        }
+
+        removeTag(kdir, tag)
+    }
+
+    if (!check) {
+        echo "Bad revision check failed"
+        currentBuild.result = 'ABORTED'
+        return
+    }
+
     timeout(time: 5, unit: 'MINUTES') {
         stage("Start") {
             def start_result = bisectStart(kdir)

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -283,6 +283,39 @@ def bisectNext(kdir, status) {
  * pipeline
  */
 
+def runCheck(kdir, kci_build, git_commit, name, run_status) {
+    def check = null
+    def tag = null
+
+    lock("${env.NODE_NAME}-build-lock") {
+        timeout(time: 60, unit: 'MINUTES') {
+            try {
+                tag = buildRevision(kdir, kci_build, git_commit, name)
+                check = true
+            } catch (error) {
+                check = false
+            }
+        }
+    }
+
+    if (!check)
+        return false
+
+    def describe = gitDescribe(kdir)
+
+    node("kernel-boot-v2") {
+        timeout(time: 120, unit: 'MINUTES') {
+            def lava_ci = env.WORKSPACE + '/lava-ci'
+            def status = runTest(lava_ci, describe)
+            check = (status == run_status ? true : false)
+        }
+    }
+
+    removeTag(kdir, tag)
+
+    return check
+}
+
 node("bisection") {
     def kci_build = env.WORKSPACE + '/kernelci-build'
     def kdir = env.WORKSPACE + '/linux'
@@ -314,34 +347,7 @@ Bad:       ${params.BAD_COMMIT}"""
     }
 
     stage("Check pass") {
-        def tag = null
-
-        lock("${env.NODE_NAME}-build-lock") {
-            timeout(time: 60, unit: 'MINUTES') {
-                try {
-                    tag = buildRevision(kdir, kci_build, params.GOOD_COMMIT,
-                                        'pass')
-                    check = true
-                } catch (error) {
-                    check = false
-                }
-            }
-        }
-
-        if (!check)
-            return
-
-        def describe = gitDescribe(kdir)
-
-        node("kernel-boot-v2") {
-            timeout(time: 120, unit: 'MINUTES') {
-                def lava_ci = env.WORKSPACE + '/lava-ci'
-                def status = runTest(lava_ci, describe)
-                check = (status == 0 ? true : false)
-            }
-        }
-
-        removeTag(kdir, tag)
+        check = runCheck(kdir, kci_build, params.GOOD_COMMIT, 'pass', 0)
     }
 
     if (!check) {
@@ -351,34 +357,7 @@ Bad:       ${params.BAD_COMMIT}"""
     }
 
     stage("Check fail") {
-        def tag = null
-
-        lock("${env.NODE_NAME}-build-lock") {
-            timeout(time: 60, unit: 'MINUTES') {
-                try {
-                    tag = buildRevision(kdir, kci_build, params.BAD_COMMIT,
-                                        'fail')
-                    check = true
-                } catch (error) {
-                    check = false
-                }
-            }
-        }
-
-        if (!check)
-            return
-
-        def describe = gitDescribe(kdir)
-
-        node("kernel-boot-v2") {
-            timeout(time: 120, unit: 'MINUTES') {
-                def lava_ci = env.WORKSPACE + '/lava-ci'
-                def status = runTest(lava_ci, describe)
-                check = (status == 2 ? true : false)
-            }
-        }
-
-        removeTag(kdir, tag)
+        check = runCheck(kdir, kci_build, params.BAD_COMMIT, 'fail', 2)
     }
 
     if (!check) {

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -209,6 +209,12 @@ PYTHON_EGG_CACHE=${egg_cache} \
     return status
 }
 
+def runTest(lava_ci, describe) {
+    cloneLAVA_CI(lava_ci)
+    submitJob(lava_ci, describe)
+    return getResult(lava_ci)
+}
+
 def bisectStart(kdir) {
     def status
 
@@ -300,9 +306,7 @@ Bad:       ${params.BAD_COMMIT}"""
         node("kernel-boot-v2") {
             timeout(time: 120, unit: 'MINUTES') {
                 def lava_ci = env.WORKSPACE + '/lava-ci'
-                cloneLAVA_CI(lava_ci)
-                submitJob(lava_ci, describe)
-                def status = getResult(lava_ci)
+                def status = runTest(lava_ci, describe)
                 check = (status == 0 ? true : false)
             }
         }
@@ -340,9 +344,7 @@ Bad:       ${params.BAD_COMMIT}"""
         node("kernel-boot-v2") {
             timeout(time: 120, unit: 'MINUTES') {
                 def lava_ci = env.WORKSPACE + '/lava-ci'
-                cloneLAVA_CI(lava_ci)
-                submitJob(lava_ci, describe)
-                def status = getResult(lava_ci)
+                def status = runTest(lava_ci, describe)
                 check = (status == 2 ? true : false)
             }
         }
@@ -398,9 +400,7 @@ Bad:       ${params.BAD_COMMIT}"""
                 timeout(time: 120, unit: 'MINUTES') {
                     stage("Test ${iteration}") {
                         def lava_ci = env.WORKSPACE + '/lava-ci'
-                        cloneLAVA_CI(lava_ci)
-                        submitJob(lava_ci, describe)
-                        status = getResult(lava_ci)
+                        status = runTest(lava_ci, describe)
                     }
                 }
             }

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -140,6 +140,13 @@ BRANCH=${params.KERNEL_BRANCH} \
     }
 }
 
+def buildRevision(kdir, kci_build, git_rev, name) {
+    checkoutRevision(kdir, git_rev)
+    def tag = createTag(kdir, name)
+    buildKernel(kdir, kci_build)
+    return tag
+}
+
 def submitJob(lava_ci, describe) {
     dir(lava_ci) {
         sh(script: "rm -rf data; mkdir data")
@@ -287,10 +294,9 @@ Bad:       ${params.BAD_COMMIT}"""
 
         lock("${env.NODE_NAME}-build-lock") {
             timeout(time: 60, unit: 'MINUTES') {
-                checkoutRevision(kdir, params.GOOD_COMMIT)
-                tag = createTag(kdir, 'pass')
                 try {
-                    buildKernel(kdir, kci_build)
+                    tag = buildRevision(kdir, kci_build, params.GOOD_COMMIT,
+                                        'pass')
                     check = true
                 } catch (error) {
                     check = false
@@ -325,10 +331,9 @@ Bad:       ${params.BAD_COMMIT}"""
 
         lock("${env.NODE_NAME}-build-lock") {
             timeout(time: 60, unit: 'MINUTES') {
-                checkoutRevision(kdir, params.BAD_COMMIT)
-                tag = createTag(kdir, 'fail')
                 try {
-                    buildKernel(kdir, kci_build)
+                    tag = buildRevision(kdir, kci_build, params.BAD_COMMIT,
+                                        'fail')
                     check = true
                 } catch (error) {
                     check = false

--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -117,13 +117,10 @@ def eggCache() {
 }
 
 def buildKernel(kdir, kci_build) {
-    def status
-
     dir(kdir) {
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
                                 variable: 'SECRET')]) {
-            status = sh(returnStatus: true,
-                        script: """
+            sh(script: """
 API=${params.API} \
 TOKEN=${SECRET} \
 TREE_NAME=${params.TREE} \
@@ -132,8 +129,6 @@ BRANCH=${params.KERNEL_BRANCH} \
 """ + kci_build + "/build.py -e -g -i -c ${params.DEFCONFIG}")
         }
     }
-
-    return status ? 1 : 0;
 }
 
 def submitJob(lava_ci, describe) {
@@ -287,19 +282,24 @@ Bad:       ${params.BAD_COMMIT}"""
 
     while (previous != current) {
         def tag = createTag(kdir, iteration)
-        def status
+        def status = null
 
         echo "Iteration #${iteration}: ${tag}"
 
         lock("${env.NODE_NAME}-build-lock") {
             timeout(time: 60, unit: 'MINUTES') {
                 stage("Build ${iteration}") {
-                    status = buildKernel(kdir, kci_build)
+                    try {
+                        buildKernel(kdir, kci_build)
+                        status = 0
+                    } catch (error) {
+                        status = 1
+                    }
                 }
             }
         }
 
-        if (!status) {
+        if (status == 0) {
             def describe = gitDescribe(kdir)
 
             node("kernel-boot-v2") {


### PR DESCRIPTION
This adds checks to prove that the given good and bad revisions are actually good and bad.  If either fails to build or the boot test result doesn't match their good/bad expected result then the job is aborted before starting an actual bisection.

It helps a lot reducing the number of false positives.