### PR TITLE
lava-v2-submit-jobs.py: remove default value for --submitted

### DIFF
--- a/lava-v2-submit-jobs.py
+++ b/lava-v2-submit-jobs.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     parser.add_argument("--username", help="username for the LAVA server")
     parser.add_argument("--token", help="token for LAVA server api")
     parser.add_argument("--repo", help="git repo for LAVA jobs")
-    parser.add_argument("--submitted", default='submitted.json',
+    parser.add_argument("--submitted",
                         help="path to JSON file to save submitted jobs data")
     args = vars(parser.parse_args())
     main(args)


### PR DESCRIPTION
In the general case when jobs are submitted and do not need to be tracked with a JSON file, the --submitted option is not used.  So remove the default value as otherwise it is always defined.

This fixes boot-v2 Jenkins jobs on staging as they don't use the --submitted option, so don't provide a --lab option either which is required when using --submitted.