### PR TITLE
T8356 qemu: use virtio in order to be able to run actual tests

### DIFF
--- a/templates/boot/qemu-generic-boot-template.jinja2
+++ b/templates/boot/qemu-generic-boot-template.jinja2
@@ -23,6 +23,7 @@
 context:
   arch: {{ ctx_arch }}
   cpu: {{ ctx_cpu }}
+  guestfs_interface: virtio
 
 actions:
 - deploy:


### PR DESCRIPTION
In order to be able to run any test beyond plain boot to a prompt on
QEMU, i.e. with some LAVA "test" steps, the guestfs interface needs to
be set to virtio.  Set this for all QEMU boot jobs so that test
templates can also inherit from it.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>