### PR TITLE
callbacks: allow configurable backend URL

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -144,6 +144,11 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
     callback_name = 'lava/boot' if plan == 'boot' else 'lava/test'
     defconfig_base = ''.join(defconfig.split('+')[:1])
 
+    # callback URL (for backend) defaults to --api value if not present
+    callback_url = config.get('callback_url')
+    if not callback_url:
+        callback_url = config.get('api')
+        
     job_params = {
         'name': job_name,
         'dtb_url': dtb_url,
@@ -179,6 +184,7 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
         'api': config.get('api'),
         'lab_name': config.get('lab'),
         'callback_name': callback_name,
+        'callback_url': callback_url,
         'context': device.get('context'),
     }
 
@@ -384,6 +390,8 @@ if __name__ == '__main__':
                         help="priority for LAVA jobs", default='high')
     parser.add_argument("--callback",
                         help="Add a callback notification to the Job YAML")
+    parser.add_argument("--callback-url",
+                        help="backend URL for callbacks (defaults to --api value)")
     parser.add_argument("--defconfigs", default=0,
                         help="Expected number of defconfigs from the API")
     parser.add_argument("--defconfig_full",

--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -42,7 +42,7 @@ notify:
   criteria:
     status: finished
   callback:
-    url: {{ api }}/callback/{{ callback_name }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
+    url: {{ callback_url }}/callback/{{ callback_name }}?lab_name={{ lab_name }}&status={STATUS}&status_string={STATUS_STRING}
     method: POST
     dataset: all
     token: {{ callback }}


### PR DESCRIPTION
Add --callback-url to configure the backend URL for sending callbacks.
When not present, will default to the --api value (current default.)

Useful for testing backend development.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>