### PR TITLE
T8427 Use local JSON file to store bisection build meta-data

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -195,6 +195,7 @@ def cloneLAVA_CI(lava_ci) {
 
 def buildKernel(kdir, kci_build) {
     dir(kdir) {
+        sh(script: "rm -f ${env._BUILD_JSON}")
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
                                 variable: 'SECRET')]) {
             sh(script: """
@@ -204,8 +205,11 @@ TREE_NAME=${params.KERNEL_TREE} \
 TREE=${params.KERNEL_URL} \
 ARCH=${params.ARCH} \
 BRANCH=${params.KERNEL_BRANCH} \
-""" + kci_build + "/build.py -e -g -i -c ${params.DEFCONFIG}")
+""" + kci_build + """/build.py -e -g -i \
+-j ${env._BUILD_JSON} \
+-c ${params.DEFCONFIG}""")
         }
+        stash(name: env._BUILD_JSON, includes: env._BUILD_JSON)
     }
 }
 
@@ -222,15 +226,15 @@ def buildRevision(kdir, kci_build, git_rev, name) {
 
 def submitJob(lava_ci, describe, hook) {
     dir(lava_ci) {
-        sh(script: "rm -rf data; mkdir data")
+        sh(script: "rm -rf ${env._BUILD_JSON}; rm -rf data; mkdir data")
+        unstash(env._BUILD_JSON)
 
         withCredentials([string(credentialsId: params.KCI_TOKEN_ID,
                                 variable: 'SECRET')]) {
             sh(script: """
 ./lava-v2-jobs-from-api.py \
 --lab=${params.LAB} \
---token=${SECRET} \
---api=${params.KCI_API_URL} \
+--builds=${env._BUILD_JSON} \
 --storage=${params.KCI_STORAGE_URL} \
 --plans=${params.PLAN} \
 --jobs=data \
@@ -374,6 +378,9 @@ def runCheck(kdir, kci_build, git_commit, name, run_status) {
 }
 
 node("bisection") {
+    /* Global pipeline constants */
+    env._BUILD_JSON = "build-data.json"
+
     def kci_build = env.WORKSPACE + '/kernelci-build'
     def kdir = env.WORKSPACE + '/linux'
     def check = null

--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -349,18 +349,26 @@ def main(args):
     token = config.get('token')
     api = config.get('api')
     storage = config.get('storage')
-
-    if not token:
-        raise Exception("No KernelCI API token provided")
-    if not api:
-        raise Exception("No KernelCI API URL provided")
-    if not storage:
-        raise Exception("No KernelCI storage URL provided")
+    builds_json = config.get('builds')
 
     print("Working on kernel {}/{}".format(
         config.get('tree'), config.get('branch')))
 
-    builds = get_builds(api, token, config)
+    if not storage:
+        raise Exception("No KernelCI storage URL provided")
+
+    if builds_json:
+        print("Getting builds from {}".format(builds_json))
+        with open(builds_json) as json_file:
+            builds = json.load(json_file)
+    else:
+        print("Getting builds from KernelCI API")
+        if not token:
+            raise Exception("No KernelCI API token provided")
+        if not api:
+            raise Exception("No KernelCI API URL provided")
+        builds = get_builds(api, token, config)
+
     print("Number of builds: {}".format(len(builds)))
 
     jobs = get_jobs_from_builds(config, builds)
@@ -379,6 +387,8 @@ if __name__ == '__main__':
                         help="KernelCI API URL")
     parser.add_argument("--storage",
                         help="KernelCI storage URL")
+    parser.add_argument("--builds",
+                        help="Path to a JSON file to use rather than the API")
     parser.add_argument("--lab", required=True,
                         help="KernelCI Lab Name")
     parser.add_argument("--jobs",


### PR DESCRIPTION
This is to avoid having to go through the KernelCI backend for each bisection iteration.  Instead, use the `build.py -j` option from https://github.com/kernelci/kernelci-build/pull/42 to create a local JSON file with the build data and use that to create the test jobs.  Only the kernel binaries get uploaded to the KernelCI backend storage.