### PR TITLE
lava-boot-v2: submit test jobs to BayLibre dev backend

### DIFF
--- a/jenkins/lava-boot-v2.sh
+++ b/jenkins/lava-boot-v2.sh
@@ -26,6 +26,9 @@ elif [ ${LAB} = "lab-collabora" ] || [ ${LAB} = "lab-collabora-dev" ]; then
 elif [ ${LAB} = "lab-baylibre" ] || [ ${LAB} = "lab-baylibre-dev" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi kselftest --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_TOKEN} --lab ${LAB}
+  # also, create test jobs, but submit results to BayLibre kernelCI backend
+  python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback kernelci-dev-baylibre-callback --callback-url http://kernelci.dev.baylibre.com:8081 --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans simple usb --token ${API_TOKEN} --priority medium
+  python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_TOKEN} --lab ${LAB}
 elif [ ${LAB} = "lab-baylibre-seattle" ]; then
   python lava-v2-jobs-from-api.py --defconfigs ${DEFCONFIG_COUNT} --callback ${CALLBACK} --api ${API} --storage ${STORAGE} --lab ${LAB} --describe ${GIT_DESCRIBE} --tree ${TREE} --branch ${BRANCH} --arch ${ARCH} --plans boot boot-kvm boot-kvm-uefi kselftest --token ${API_TOKEN} --priority medium
   python lava-v2-submit-jobs.py --username kernel-ci --jobs ${LAB} --token ${LAVA_BAYLIBRE_SEATTLE_TOKEN} --lab ${LAB}


### PR DESCRIPTION
Create "simple" and "usb" plans and submit to the BayLibre dev
kernelCI backend.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>