### PR TITLE
Add socionext synquacer devbox devices

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -291,6 +291,8 @@ def get_jobs_from_builds(config, builds):
             build['dtb_dir_data'].extend(LEGACY_X86_PLATFORMS)
         if arch in ['arm', 'arm64', 'x86'] and 'defconfig' in defconfig:
             build['dtb_dir_data'].append('qemu')
+        if arch == 'arm64':
+            build['dtb_dir_data'].append('arm64-no-dtb')
 
         for plan in config.get('plans'):
             opts = {

--- a/lib/device_map.py
+++ b/lib/device_map.py
@@ -1782,6 +1782,28 @@ dove_cubox = {'device_type': 'dove-cubox',
                        'fastboot': False,
                        'mach': 'mvebu'}
 
+synquacer_acpi = {'device_type': 'synquacer-acpi',
+       'templates': ['generic-grub-tftp-ramdisk-template.jinja2'],
+       'kernel_defconfig_blacklist': [],
+       'defconfig_blacklist': ['allmodconfig'],
+       'kernel_blacklist': ['v3.'],
+       'nfs_blacklist': [],
+       'lpae': False,
+       'fastboot': False,
+       'defconfig_whitelist': ['defconfig'],
+       'mach': 'socionext'}
+
+synquacer_dtb = {'device_type': 'synquacer-dtb',
+       'templates': ['generic-grub-tftp-ramdisk-template.jinja2'],
+       'kernel_defconfig_blacklist': [],
+       'defconfig_blacklist': ['allmodconfig'],
+       'kernel_blacklist': ['v3.'],
+       'nfs_blacklist': [],
+       'lpae': False,
+       'fastboot': False,
+       'defconfig_whitelist': ['defconfig'],
+       'mach': 'socionext'}
+
 device_map = {'alpine-db.dtb': [alpine_db],
               'alpine-v2-evp.dtb': [alpine_v2_evp],
               'bcm2835-rpi-b-plus.dtb': [bcm2835_rpi_b_plus],
@@ -1898,4 +1920,5 @@ device_map = {'alpine-db.dtb': [alpine_db],
               'armada-xp-openblocks-ax3-4.dtb': [openblocks_ax3],
               'vf610-zii-dev-rev-b.dtb': [vf610_zii_dev_rev_b],
               'dove-cubox.dtb' : [dove_cubox],
-              'r8a7791-porter.dtb': [r8a7791_porter]}
+              'r8a7791-porter.dtb': [r8a7791_porter],
+              'arm64-no-dtb': [synquacer_acpi, synquacer_dtb]}


### PR DESCRIPTION
For ARM64, add a platform to device_map for devices that do not
use a DTB.