### PR TITLE
templates/boot: add (initramfs) boot prompt

### DIFF
--- a/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
@@ -18,5 +18,6 @@
     prompts:
       - 'linaro-test'
       - 'root@debian:~#'
+      - '(initramfs)'
       - '/ #'
 {% endblock %}


### PR DESCRIPTION
When using a debian initramfs, if the boot falls through to the
ramdisk, the shell prompt is "(initramfs)".  Add that to the list
of expected prompts.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>