### PR TITLE
Pass the image shell prompt to the templates

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -143,6 +143,8 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
 
     nfsrootfs_url = None
     initrd_url = None
+    rootfs_prompt = "\(initramfs\)"
+
     if 'kselftest' in plan:
         initrd_url = KSELFTEST_INITRD_URL.format(initrd_arch)
     else:
@@ -150,11 +152,16 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
     if 'nfs' in plan:
         nfsrootfs_url = NFSROOTFS_URL.format(initrd_arch)
         initrd_url = None
+        rootfs_prompt = "/ #"
     if build['modules']:
         modules_url = urlparse.urljoin(
             storage, '/'.join([url_px, build['modules']]))
     else:
         modules_url = None
+
+    # hack for compatibility
+    if (initrd_url and 'buildroot' in initrd_url) or (nfsrootfs_url and 'buildroot' in nfsrootfs_url):
+        rootfs_prompt = "/ #"
 
     device_type = device['device_type']
     if device_type.startswith('qemu') or device_type == 'kvm':
@@ -195,6 +202,7 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
         'nfsrootfs_url': nfsrootfs_url,
         'lab_name': config.get('lab'),
         'context': device.get('context'),
+        'rootfs_prompt': rootfs_prompt,
     }
 
     add_callback_params(job_params, config, plan)

--- a/templates/boot-be/generic-uboot-tftp-ramdisk-boot-be-template.jinja2
+++ b/templates/boot-be/generic-uboot-tftp-ramdisk-boot-be-template.jinja2
@@ -16,7 +16,5 @@
     method: u-boot
     commands: ramdisk
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
+++ b/templates/boot-nfs/generic-depthcharge-tftp-nfs-template.jinja2
@@ -18,7 +18,5 @@
     method: depthcharge
     commands: nfs
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot-nfs/generic-grub-tftp-nfs-template.jinja2
+++ b/templates/boot-nfs/generic-grub-tftp-nfs-template.jinja2
@@ -16,7 +16,5 @@
     method: grub
     commands: nfs
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot-nfs/generic-ipxe-tftp-nfs-template.jinja2
+++ b/templates/boot-nfs/generic-ipxe-tftp-nfs-template.jinja2
@@ -16,7 +16,5 @@
     method: ipxe
     commands: nfs
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
+++ b/templates/boot-nfs/generic-uboot-tftp-nfs-template.jinja2
@@ -16,7 +16,5 @@
     method: u-boot
     commands: nfs
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot/generic-depthcharge-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-depthcharge-tftp-ramdisk-template.jinja2
@@ -18,7 +18,5 @@
     method: depthcharge
     commands: ramdisk
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot/generic-grub-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-grub-tftp-ramdisk-template.jinja2
@@ -16,7 +16,5 @@
     method: grub
     commands: ramdisk
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot/generic-ipxe-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-ipxe-tftp-ramdisk-template.jinja2
@@ -16,7 +16,5 @@
     method: ipxe
     commands: ramdisk
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
+++ b/templates/boot/generic-uboot-tftp-ramdisk-template.jinja2
@@ -16,8 +16,5 @@
     method: u-boot
     commands: ramdisk
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '(initramfs)'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}

--- a/templates/boot/qemu-generic-boot-template.jinja2
+++ b/templates/boot/qemu-generic-boot-template.jinja2
@@ -45,7 +45,5 @@ actions:
     method: qemu
     media: tmpfs
     prompts:
-      - 'linaro-test'
-      - 'root@debian:~#'
-      - '/ #'
+      - '{{ rootfs_prompt }}'
 {% endblock %}


### PR DESCRIPTION
As the jobs script knows which rootfs the job will use, let that decide what the image prompt should be set to.

The hack for buildroot compatibility can be removed when we move over to the debian images. Also the debian NFS setting might not be correct right now.