### PR TITLE
RFC: Increase timeout values

### DIFF
--- a/templates/base/kernel-ci-base.jinja2
+++ b/templates/base/kernel-ci-base.jinja2
@@ -56,9 +56,9 @@ notify:
 job_name: {{ name }}
 timeouts:
   job:
-    minutes: 10
+    minutes: 30
   action:
-   minutes: 10
+    minutes: 30
   actions:
     power-off:
       seconds: 30


### PR DESCRIPTION
Some testsuites like IGT take more than 10 minutes when running all the tests included. 
This doesn't affect yet any of the lava jobs included but it's often a problem when doing test and sooner or later we'll add in git a test plan needing a higher value.
What about increasing the timeout values?