### PR TITLE
templates/sleep: use /dev/kmsg for LAVA test signals

### DIFF
--- a/templates/sleep/sleep.jinja2
+++ b/templates/sleep/sleep.jinja2
@@ -13,9 +13,9 @@
           - functional
         run:
           steps:
-            - dmesg -n 6  # Silence KERN_INFO as it confuses LAVA on wakeup
             - for i in $(seq 1 10); do lava-test-case rtcwake-mem-$i --shell rtcwake -d rtc0 -m mem -s 1; done
             - for i in $(seq 1 10); do lava-test-case rtcwake-freeze-$i --shell rtcwake -d rtc0 -m freeze -s 1; done
+      lava-signal: kmsg
       from: inline
       name: sleep
       path: inline/sleep.yaml


### PR DESCRIPTION
Remove workaround with dmesg and use new feature from lava
to use /dev/kmsg for LAVA test signals.
This change requires a LAVA instance with this patch
https://review.linaro.org/#/c/25377/

A couple of tests of this change:
https://lava.collabora.co.uk/scheduler/job/1183582
https://lava.collabora.co.uk/scheduler/job/1183583