### PR TITLE
update usb test plan to check usb devices after suspend

### DIFF
--- a/lava-v2-jobs-from-api.py
+++ b/lava-v2-jobs-from-api.py
@@ -159,7 +159,7 @@ def get_job_params(config, template, opts, device, build, defconfig, plan):
     elif plan in ['v4l2', 'igt']:
         initrd_url = DEBIANTESTS_INITRD_URL.format(debian_initrd_arch)
         rootfs_prompt = "/ #"
-    elif plan in ['cros-ec']:
+    elif plan in ['cros-ec', 'usb', 'sleep']:
         initrd_url = DEBIAN_INITRD_URL.format(debian_initrd_arch)
         rootfs_prompt = "/ #"
     else:

--- a/templates/usb/usb.jinja2
+++ b/templates/usb/usb.jinja2
@@ -13,8 +13,14 @@
           - functional
         run:
           steps:
-            - lsusb
             - lava-test-case usb-presence --shell test -n \"$(lsusb)\"
+            - lsusb | awk {'print $6'} | sort > before.txt
+            - for i in $(seq 1 3); do /usr/sbin/rtcwake -d rtc0 -m freeze -s 1; done
+            - lsusb | awk {'print $6'} | sort > after-freeze.txt
+            - lava-test-case compare-freeze --shell diff -u before.txt after-freeze.txt
+            - for i in $(seq 1 3); do /usr/sbin/rtcwake -d rtc0 -m mem -s 1; done
+            - lsusb | awk {'print $6'} | sort > after-mem.txt
+            - lava-test-case compare-mem --shell diff -u before.txt after-mem.txt
       lava-signal: kmsg
       from: inline
       name: usb


### PR DESCRIPTION
Add two more tests to check the presence of all the usb devices after suspending the system using rtcwake with the modes 'mem' and   'freeze'.  
Test run: https://lava.collabora.co.uk/scheduler/job/1187502

@khilman the second commit, update the usb and sleep test plans to use the Debian images. These tests are also run in the baylibre lab, say something if it's a problem for you.