### PR TITLE
templates/usb: use /dev/kmsg for LAVA test signals

### DIFF
--- a/templates/usb/usb.jinja2
+++ b/templates/usb/usb.jinja2
@@ -15,6 +15,7 @@
           steps:
             - lsusb
             - lava-test-case usb-presence --shell test -n \"$(lsusb)\"
+      lava-signal: kmsg
       from: inline
       name: usb
       path: inline/usb.yaml


### PR DESCRIPTION
Use a feature from lava to use /dev/kmsg for LAVA test signals.
This change requires a LAVA instance with this patch included
in LAVA releases after 2018.5
https://review.linaro.org/#/c/25377/

An example test using this: https://lava.collabora.co.uk/scheduler/job/1201704
( from this one failing: https://lava.collabora.co.uk/scheduler/job/1200796 )