### PR TITLE
T10166 bisect.jpl: call build.py -J to dump meta-data to JSON

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -214,7 +214,7 @@ TREE=${params.KERNEL_URL} \
 ARCH=${params.ARCH} \
 BRANCH=${params.KERNEL_BRANCH} \
 """ + kci_build + """/build.py -e -g -i \
--j ${env._BUILD_JSON} \
+-J ${env._BUILD_JSON} \
 -c ${params.DEFCONFIG}""")
         }
         stash(name: env._BUILD_JSON, includes: env._BUILD_JSON)


### PR DESCRIPTION
Use the new `build.py -J` option to dump the builds meta-data to JSON
rather than `-j` which is now being used for the number of parallel
builds.

Note: This should be merged at the same time as https://github.com/kernelci/kernelci-build-staging/pull/51