### PR TITLE
bisect.jpl: remove Jenkins job number from email subject

### DIFF
--- a/jenkins/bisect.jpl
+++ b/jenkins/bisect.jpl
@@ -363,7 +363,7 @@ def bisectNext(kdir, status) {
  */
 
 def pushResults(kdir, checks, params_summary) {
-    def subject = "${params.KERNEL_TREE}/${params.KERNEL_BRANCH} ${params.PLAN} bisection: ${params.KERNEL_NAME} on ${params.TARGET} #${env.BUILD_NUMBER}"
+    def subject = "${params.KERNEL_TREE}/${params.KERNEL_BRANCH} ${params.PLAN} bisection: ${params.KERNEL_NAME} on ${params.TARGET}"
 
     def lava_ci = env.WORKSPACE + '/lava-ci'
     cloneLAVA_CI(lava_ci)

--- a/push-bisection-results.py
+++ b/push-bisection-results.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     from StringIO import StringIO
 import urlparse
-from lib import configuration, device_map
+from lib import configuration
 
 
 def git_summary(repo, revision):


### PR DESCRIPTION
The Jenkins job number is not useful for recipients of the email
reports, only when debugging issues with access to Jenkins.  It can
now be removed as bisections are enabled in production.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>